### PR TITLE
Add UE Assimp

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ A categorized collection of awesome opensource Unreal Engine 4 repos
 * [Cesium for Unreal](https://github.com/CesiumGS/cesium-unreal) - Bringing the 3D geospatial ecosystem to Unreal Engine
 * [AccelByte UE4 SDK](https://github.com/AccelByte/accelbyte-ue4-sdk) - AccelByte UE4 SDK is a plugin for Unreal Engine 4
 * [MindMaker](https://github.com/krumiaa/MindMaker) - MindMaker UE4 Machine Learning Toolkit
+* [UEAssimp](https://github.com/irajsb/UE4_Assimp) - Assimp Mesh Importer for UE 
 
 ## Data Exporter
 * [ServerRecast](https://github.com/darkwere/ServerRecast) - UE4 plugin for navmesh export


### PR DESCRIPTION
Added assimp mesh importer to the list .  You can also find link to this plugin in official Assimp repo https://github.com/assimp/assimp . 
I didn't put assimp in importers or exporters tab since it supports both import and export so not sure about that .